### PR TITLE
Update run commands to support newer versions of node

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,2 @@
+# Compatibility
+This project requires node v17+ to run.

--- a/client/package.json
+++ b/client/package.json
@@ -10,8 +10,8 @@
     "react-scripts": "2.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Resolves #5 

# Background/Context
Looks like the issue was caused by an incompatibility error with node major versions > v17. We can work around this by running with `--openssl-legacy-provider`. [See here for reference](https://github.com/webpack/webpack/issues/14532).

Note: The `--openssl-legacy-provider` option is not recognized for versions < v17 and will result in the client failing to start unless removed.

# What changed
* Updated run and build commands to include `--openssl-legacy-provider` by default
* Added README describing node version requirements