### PR TITLE
Refactor client -> API connection to use env variables

### DIFF
--- a/client/.env.default
+++ b/client/.env.default
@@ -1,0 +1,3 @@
+# Values describing connection to backend API
+REACT_APP_API_HOST=
+REACT_APP_API_PORT=

--- a/client/README.md
+++ b/client/README.md
@@ -27,7 +27,7 @@ docker build -t macro-web-client .
 
 The image can then be run with:
 ```
-docker container run <EXTERNAL_PORT>:3000 -d macro-web-client
+docker container run -p <EXTERNAL_PORT>:3000 -d macro-web-client
 ```
 
 For example, running `docker container run -p 3000:3000 -d macro-web-client` will allow the web-client to be accessed at `localhost:3000`.

--- a/client/README.md
+++ b/client/README.md
@@ -4,6 +4,13 @@ This module contains the frontend client code and the web server responsible for
 ## Compatibility
 This project requires node v17+ to run.
 
+## Configuration
+To configure the frontend client to connect to the supporting backend API, copy the template from `.env.default` to a new `.env` file and fill in the specified values. For example:
+```shell
+REACT_APP_API_HOST=localhost
+REACT_APP_API_PORT=3001
+```
+
 ## Running with Node
 The recommended way to run this project for development is with node. To do so, run the following command:
 ```

--- a/client/src/components/DailyTotals.jsx
+++ b/client/src/components/DailyTotals.jsx
@@ -14,7 +14,7 @@ export default class DailyTotals extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     // Update daily macro totals
-    fetch('http://localhost:3001/totals?date='+nextProps.date, {
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/totals?date=`+nextProps.date, {
       method: 'GET',
       headers: {
         'Accept': 'application/json',

--- a/client/src/components/DateForm.jsx
+++ b/client/src/components/DateForm.jsx
@@ -11,7 +11,7 @@ export default class DateForm extends React.Component {
       <div style={{textAlign: 'center'}} >
         <Button onClick={() => this.props.onDayChange(-1)}><NavigateBefore /></Button>
         <TextField type="date" value={this.props.date} onChange={this.props.onDateChange} />
-	    <Button onClick={() => this.props.onDayChange(1)}><NavigateNext /></Button>
+        <Button onClick={() => this.props.onDayChange(1)}><NavigateNext /></Button>
       </div>
     )
   }

--- a/client/src/components/FoodSearch.jsx
+++ b/client/src/components/FoodSearch.jsx
@@ -17,7 +17,7 @@ export default class FoodSearch extends React.Component {
   onSubmit = (e) => {
     e.preventDefault();
     // Query database for specified food
-    fetch('http://localhost:3001/foods?food='+this.state.foodSearch)
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/foods?food=`+this.state.foodSearch)
       .then(response => response.json())
       .then(json => {
         if (json.errors) {
@@ -73,7 +73,7 @@ class SearchResult extends React.Component {
   onSubmit = (e) => {
     e.preventDefault();
     // Send new record data to API to update user record
-    fetch('http://localhost:3001/records', {
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/records`, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/client/src/components/LoginMenu.jsx
+++ b/client/src/components/LoginMenu.jsx
@@ -24,7 +24,7 @@ export default class LoginMenu extends React.Component {
   // Attempt to log a user in
   handleLogin = (state) => {
     // Send registration form state to API
-    fetch('http://localhost:3001/login', {
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/login`, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -47,7 +47,7 @@ export default class LoginMenu extends React.Component {
   // Attempt to register a new user
   handleRegister = (state) => {
     // Send registration form state to API
-    fetch('http://localhost:3001/register', {
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/register`, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/client/src/components/NewFoodForm.jsx
+++ b/client/src/components/NewFoodForm.jsx
@@ -34,7 +34,7 @@ export default class NewFoodForm extends React.Component {
   onSubmit = (e) => {
     e.preventDefault();
     // Send new food data to API to add to food listing
-    fetch('http://localhost:3001/foods', {
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/foods`, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -40,7 +40,7 @@ class App extends React.Component {
 
   handleUpdate() {
     // Update daily meal record
-    fetch('http://localhost:3001/records?date='+this.state.date, {
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/records?date=`+this.state.date, {
       method: 'GET',
       headers: {
         'Accept': 'application/json',
@@ -74,7 +74,7 @@ class App extends React.Component {
 
   handleDelete(id) {
     // Delete a record
-    fetch('http://localhost:3001/records?id='+id, {
+    fetch(`http://${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}/records?id=`+id, {
       method: 'DELETE',
       headers: {
         'Accept': 'application/json',

--- a/server/README.md
+++ b/server/README.md
@@ -38,7 +38,7 @@ docker build -t macro-api-server .
 
 The image can then be run with:
 ```
-docker container run <EXTERNAL_PORT>:3001 -d macro-api-server
+docker container run -p <EXTERNAL_PORT>:3001 -d macro-api-server
 ```
 
 For example, running `docker container run -p 3001:3001 -d macro-api-server` will allow the REST API to be accessed at `localhost:3001`.


### PR DESCRIPTION
# Motivation
This change is in support of #3.

For deployment, it's easier to configure connection info if it's defined as a variable declared in a single place.

# What changed
* Refactored frontend client to use env variables specified in `.env` for API URL and port